### PR TITLE
Additional test

### DIFF
--- a/verification/tests.py
+++ b/verification/tests.py
@@ -27,6 +27,10 @@ TESTS = {
         {
             "input": "hi",
             "answer": "Hi."
+        },
+        {
+            "input": "welcome to New York",
+            "answer": "Welcome to New York."
         }
     ]
 }


### PR DESCRIPTION
IMO [this solution](https://py.checkio.org/mission/correct-sentence/publications/suic/python-3/short-but-incorrect/) is incorrect as:

```python
>>> correct_sentence("New York")  # Should be "New York."
New york.
```